### PR TITLE
Fix issue with double routing in class page

### DIFF
--- a/web/src/components/ProfessorList.js
+++ b/web/src/components/ProfessorList.js
@@ -20,7 +20,7 @@ const ProfessorList = ({ professors, handleProfessorClick }) => {
             onClick={() => handleProfessorClick(professor)}  // Use the click handler
           >
             <Link 
-               to={`/professor/${encodeURIComponent(professor.toLowerCase().replace(/\s+/g, '-'))}`}
+               to='#' // no navigation because it is handled in handleProfessorClick
               className="flex items-center justify-between text-blue-600 hover:text-blue-800"
             >
               <span>{professor}</span>


### PR DESCRIPTION
Fixed a small issue where pressing an associate professor would double route.